### PR TITLE
`serif dev` server should serve up 404s

### DIFF
--- a/lib/serif/server.rb
+++ b/lib/serif/server.rb
@@ -7,6 +7,8 @@ class DevelopmentServer
   class DevApp < Sinatra::Base
     set :public_folder, Dir.pwd
 
+    not_found { "Resource not found" }
+
     get "/" do
       File.read(File.expand_path("_site/index.html"))
     end
@@ -22,7 +24,7 @@ class DevelopmentServer
       # make a naive assumption that there's a 404 file at 404.html
       file ||= Dir[File.expand_path("_site/404.html")].first
 
-      File.read(file)
+      file ? File.read(file) : 404
     end
   end
 


### PR DESCRIPTION
1. `serif new`
2. `serif generate`
3. `serif dev`
4. Visit http://localhost:8000/

The `serif dev` process gives a bunch of errors because `File.read(file)` was called but `file` was `nil`. This comes from the `/favicon.ico` request, and since the file doesn't exist, `File.read(file)` fails.

The fix is to define a `not_found` block and return `404` for the `get *` handler.
