### PR TITLE
Allow a nil path value without breaking brand new Draft instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # next release
 
-* ...
+* Prevent broken initial drafts, where the path is nil, and thus fix errors on the new draft admin page. (#57)
 
 # v0.5.1
 

--- a/lib/serif/content_file.rb
+++ b/lib/serif/content_file.rb
@@ -51,13 +51,21 @@ class ContentFile
     @cached_headers = nil
   end
   
-  # Returns true if the file is in the directory for draft content.
+  # Returns true if the file is in the directory for draft content, or
+  # has no saved path yet.
   def draft?
+    return true if !path
+
     File.dirname(path) == File.join(site.directory, Draft.dirname)
   end
 
-  # Returns true if the file is in the directory for published posts.
+  # Returns true if the file is in the directory for published posts,
+  # false otherwise.
+  #
+  # If there is no path at all, returns false.
   def published?
+    return false if !path
+
     File.dirname(path) == File.join(site.directory, Post.dirname)
   end
   

--- a/test/content_file_spec.rb
+++ b/test/content_file_spec.rb
@@ -36,6 +36,15 @@ describe Serif::ContentFile do
     end
   end
 
+  describe "draft and published status" do
+    it "can handle a nil path" do
+      c = Serif::ContentFile.new(subject)
+      c.path.should be_nil
+      c.draft?.should be_true
+      c.published?.should be_false
+    end
+  end
+
   describe "draft?" do
     it "is true if the file is in the _drafts directory" do
       subject.drafts.each do |d|
@@ -51,6 +60,12 @@ describe Serif::ContentFile do
   end
 
   describe "published?" do
+    it "can handle a nil path" do
+      d = Serif::Post.new(subject)
+      d.draft?.should be_true
+      d.published?.should be_false
+    end
+
     it "is true if the file is in the _posts directory" do
       subject.posts.each do |p|
         p.published?.should be_true

--- a/test/draft_spec.rb
+++ b/test/draft_spec.rb
@@ -246,6 +246,12 @@ describe Serif::Draft do
         liq.key?(e).should be_true
       end
     end
+
+    context "for an initial draft" do
+      it "works fine" do
+        expect { Serif::Draft.new(@site).to_liquid }.to_not raise_error
+      end
+    end
   end
 
   describe "#save" do


### PR DESCRIPTION
For brand-new Draft/ContentFile instances with a nil path value, these
two methods are broken, and thus so is to_liquid. This primarily breaks
the new draft page, where nothing is set.

See #57, which this fixes.
