### PR TITLE
Support admin.js

### DIFF
--- a/statics/templates/admin/layout.liquid
+++ b/statics/templates/admin/layout.liquid
@@ -537,6 +537,7 @@ body > nav ul li:last-child {
 			});
 		});
 	</script>
+	<script src="/js/admin/admin.js"></script>
 </head>
 <body id="admin">
 	<nav>


### PR DESCRIPTION
Pull in `/js/admin/admin.js` in the same way we do `admin.css`. Primarily added to support MathJax without having to hard-code URLs so that different MathJax configurations can be set.
