### PR TITLE
Prevent /tmp from being filled up over time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # next release
 
-* ...
+* Prevent /tmp from filling up over time. (#77)
 
 # v0.6
 

--- a/lib/serif/site.rb
+++ b/lib/serif/site.rb
@@ -390,6 +390,7 @@ class Site
 
     FileUtils.mv("tmp/_site", ".") && FileUtils.rm_rf("tmp/_site")
     FileUtils.rmdir("tmp")
+    Dir["/tmp/_site.*"][0..-6].each { |d| FileUtils.rm_rf(d) }
   end
 
   private


### PR DESCRIPTION
Site generations now keep only the last 5 generated `_site` copies in `/tmp` instead of a perpetually growing amount.
